### PR TITLE
Rename `Vector(Approx)` -> `VectorSpace(Approx)`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "algebra"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Brendan Zabarauskas", "Darin Morrison"]
 description = "Abstract algebra for Rust"
 keywords = ["algebra", "monoids", "math"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Abstract algebra for Rust
 
-[![Build Status](https://travis-ci.org/bjz/algebra.png?branch=master)](https://travis-ci.org/bjz/algebra)
+[![Build Status](https://travis-ci.org/brendanzab/algebra.png?branch=master)](https://travis-ci.org/brendanzab/algebra)
 
 ~~~
 |(• ◡•)|ノ〵(❍ᴥ❍⋃)     - "ALGEBRAIC!!!"

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -152,13 +152,13 @@
 //!                           \       /
 //!                            |     |
 //!                            V     V
-//!                         Vector<Scalar>
+//!                         VectorSpace<Scalar>
 //! ~~~
 //!
 //! The following traits are provided:
 //!
 //! - `Module`(`Approx`)?
-//! - `Vector`(`Approx`)?
+//! - `VectorSpace`(`Approx`)?
 //!
 //! # Quickcheck properties
 //!
@@ -205,8 +205,8 @@ pub use self::ring::Field;
 
 pub use self::module::ModuleApprox;
 pub use self::module::Module;
-pub use self::module::VectorApprox;
-pub use self::module::Vector;
+pub use self::module::VectorSpaceApprox;
+pub use self::module::VectorSpace;
 
 mod magma;
 mod quasigroup;

--- a/src/structure/module.rs
+++ b/src/structure/module.rs
@@ -49,13 +49,13 @@ pub trait Module<S: RingCommutative>
 {}
 
 /// A approximate vector space has an approx. module structure over an approx. field.
-pub trait VectorApprox<S: FieldApprox>
+pub trait VectorSpaceApprox<S: FieldApprox>
     : ModuleApprox<S>
 {}
 
 
 /// A vector space has a module structure over a field instead of a ring.
-pub trait Vector<S: Field>
-    : VectorApprox<S>
+pub trait VectorSpace<S: Field>
+    : VectorSpaceApprox<S>
     + Module<S>
 {}


### PR DESCRIPTION
Also bumps the cargo version number.