### PR TITLE
Define euclidean space.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ license = "Apache-2.0"
 [lib]
 name = "algebra"
 
+[dependencies]
+num = "0.1.*"
+
 [dev-dependencies]
 quickcheck = "0.2"
 quickcheck_macros = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 name = "algebra"
 
 [dependencies]
-num = "0.1.*"
+num-traits = "0.1.*"
 
 [dev-dependencies]
 quickcheck = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 #[cfg(test)]
 extern crate quickcheck;
 
-extern crate num;
+extern crate num_traits as num;
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@
 #[cfg(test)]
 extern crate quickcheck;
 
+extern crate num;
+
 #[macro_use]
 mod macros;
 pub mod cmp;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -55,8 +55,22 @@ pub trait Recip {
     fn recip(self) -> Self::Result;
 }
 
-impl Recip for f32 { type Result = Self; #[inline] fn recip(self) -> f32 { 1.0 / self } }
-impl Recip for f64 { type Result = Self; #[inline] fn recip(self) -> f64 { 1.0 / self } }
+impl Recip for f32 {
+    type Result = Self;
+
+    #[inline]
+    fn recip(self) -> f32 {
+        1.0 / self
+    }
+}
+
+impl Recip for f64 {
+    type Result = Self;
+    #[inline]
+    fn recip(self) -> f64 {
+        1.0 / self
+    }
+}
 
 /// Trait implemented by types representing operators.
 pub trait Op: Copy {

--- a/src/structure/abelian.rs
+++ b/src/structure/abelian.rs
@@ -14,7 +14,7 @@
 
 #![allow(missing_docs)]
 
-use ops::{Op, Additive};
+use ops::{Op, Additive, Multiplicative};
 
 use structure::GroupApprox;
 use structure::Group;
@@ -35,7 +35,8 @@ pub trait GroupAbelianApprox<O: Op>
     }
 }
 
-impl_marker!(GroupAbelianApprox<Additive>; i8, i16, i32, i64);
+impl_marker!(GroupAbelianApprox<Additive>; i8, i16, i32, i64, f32, f64);
+impl_marker!(GroupAbelianApprox<Multiplicative>; f32, f64);
 
 /// A commutative group.
 ///

--- a/src/structure/group.rs
+++ b/src/structure/group.rs
@@ -48,12 +48,13 @@ impl_marker!(Group<Additive>; i8, i16, i32, i64);
 /// The group `E(n)` of isometries, i.e., rotations, reflexions, and translations.
 pub trait EuclideanGroupApprox<S: RealApprox, E: EuclideanSpaceApprox<S>>: GroupApprox<Multiplicative> {
     /// Applies this group's action on a point from the euclidean space.
-    fn transform_point(&self, pt: &E);
+    fn transform_point(&self, pt: &E) -> E;
+
     /// Applies this group's action on a vector from the euclidean space.
     ///
-    /// If `v` is a vector and `a, b` two point such that `v = a - b` the action `∘` on a vector is
-    /// defined as `self ∘ v = (self × a) - (self × b)`.
-    fn transform_vector(&self, v: &E::Vector);
+    /// If `v` is a vector and `a, b` two point such that `v = a - b`, the action `∘` on a vector
+    /// is defined as `self ∘ v = (self × a) - (self × b)`.
+    fn transform_vector(&self, v: &E::Vector) -> E::Vector;
 }
 
 /// The group `SE(n)` of orientation-preserving isometries, i.e., rotations and translations.

--- a/src/structure/group.rs
+++ b/src/structure/group.rs
@@ -18,6 +18,8 @@ use structure::LoopApprox;
 use structure::Loop;
 use structure::MonoidApprox;
 use structure::Monoid;
+use structure::EuclideanSpaceApprox;
+use structure::RealApprox;
 
 /// An approximate group is an approx. loop and an approx. monoid simultaneously.
 pub trait GroupApprox<O: Op>
@@ -36,3 +38,44 @@ pub trait Group<O: Op>
 {}
 
 impl_marker!(Group<Additive>; i8, i16, i32, i64);
+
+/*
+ *
+ * A subgroup trait inherit from its parent groups.
+ *
+ */
+
+/// The group `E(n)` of isometries, i.e., rotations, reflexions, and translations.
+pub trait EuclideanGroupApprox<S: RealApprox, E: EuclideanSpaceApprox<S>>: GroupApprox<Multiplicative> {
+    /// Applies this group's action on a point from the euclidean space.
+    fn transform_point(&self, pt: &E);
+    /// Applies this group's action on a vector from the euclidean space.
+    ///
+    /// If `v` is a vector and `a, b` two point such that `v = a - b` the action `∘` on a vector is
+    /// defined as `self ∘ v = (self × a) - (self × b)`.
+    fn transform_vector(&self, v: &E::Vector);
+}
+
+/// The group `SE(n)` of orientation-preserving isometries, i.e., rotations and translations.
+///
+/// This is a subgroup of `E(n)`.
+pub trait SpecialEuclideanGroupApprox<S: RealApprox, E: EuclideanSpaceApprox<S>>: EuclideanGroupApprox<S, E> {
+}
+
+/// The group `T(n)` of translations.
+///
+/// This is a subgroup of `SE(n)`.
+pub trait TranslationGroupApprox<S: RealApprox, E: EuclideanSpaceApprox<S>>: SpecialEuclideanGroupApprox<S, E> {
+}
+
+/// The group `O(n)` of n-dimensional rotations and reflexions.
+///
+/// This is a subgroup of `E(n)`.
+pub trait OrthogonalGroupApprox<S: RealApprox, E: EuclideanSpaceApprox<S>>: EuclideanGroupApprox<S, E> {
+}
+
+/// The group `SO(n)` of n-dimensional of rotations.
+///
+/// This is a subgroup of `O(n)`.
+pub trait SpecialOrthogonalGroupApprox<S: RealApprox, E: EuclideanSpaceApprox<S>>: OrthogonalGroupApprox<S, E> {
+}

--- a/src/structure/group.rs
+++ b/src/structure/group.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ops::{Op, Additive};
+use ops::{Op, Additive, Multiplicative};
 
 use structure::LoopApprox;
 use structure::Loop;
@@ -25,7 +25,8 @@ pub trait GroupApprox<O: Op>
     + MonoidApprox<O>
 {}
 
-impl_marker!(GroupApprox<Additive>; i8, i16, i32, i64);
+impl_marker!(GroupApprox<Additive>; i8, i16, i32, i64, f32, f64);
+impl_marker!(GroupApprox<Multiplicative>; f32, f64);
 
 /// A group is a loop and a monoid at the same time.
 pub trait Group<O: Op>

--- a/src/structure/loop_.rs
+++ b/src/structure/loop_.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ops::{Op, Additive};
+use ops::{Op, Additive, Multiplicative};
 use ident::Identity;
 
 use structure::Quasigroup;
@@ -31,7 +31,8 @@ pub trait LoopApprox<O: Op>
     + Identity<O>
 {}
 
-impl_marker!(LoopApprox<Additive>; i8, i16, i32, i64);
+impl_marker!(LoopApprox<Additive>; i8, i16, i32, i64, f32, f64);
+impl_marker!(LoopApprox<Multiplicative>; f32, f64);
 
 /// A quasigroup with an unique identity element.
 ///

--- a/src/structure/magma.rs
+++ b/src/structure/magma.rs
@@ -31,6 +31,7 @@ pub trait MagmaApprox<O: Op>
     /// Performs an operation.
     fn approx(self, Self) -> Self;
     /// Performs specific operation.
+    #[inline]
     fn ap(self, _: O, lhs: Self) -> Self {
         self.approx(lhs)
     }
@@ -46,10 +47,12 @@ pub trait Magma<O: Op>
     + MagmaApprox<O>
 {
     /// Performs an operation.
+    #[inline]
     fn operate(self, lhs: Self) -> Self {
         self.approx(lhs)
     }
     /// Performs specific operation.
+    #[inline]
     fn op(self, _: O, lhs: Self) -> Self {
         self.operate(lhs)
     }
@@ -58,6 +61,7 @@ pub trait Magma<O: Op>
 impl<T> MagmaApprox<Additive> for T
 where T: Add<T, Output=T> + PartialEq + ApproxEq + Clone,
 {
+    #[inline]
     fn approx(self, lhs: Self) -> Self {
         self + lhs
     }
@@ -70,6 +74,7 @@ where T: MagmaApprox<Additive> + Eq,
 impl<T> MagmaApprox<Multiplicative> for T
 where T: Mul<T, Output=T> + PartialEq + ApproxEq + Clone,
 {
+    #[inline]
     fn approx(self, lhs: Self) -> Self {
         self * lhs
     }

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -192,6 +192,10 @@ pub use self::monoid::Monoid;
 
 pub use self::group::GroupApprox;
 pub use self::group::Group;
+pub use self::group::OrthogonalGroupApprox;
+pub use self::group::SpecialOrthogonalGroupApprox;
+pub use self::group::EuclideanGroupApprox;
+pub use self::group::SpecialEuclideanGroupApprox;
 
 pub use self::abelian::GroupAbelianApprox;
 pub use self::abelian::GroupAbelian;
@@ -209,10 +213,13 @@ pub use self::module::ModuleApprox;
 pub use self::module::Module;
 pub use self::module::VectorSpaceApprox;
 pub use self::module::VectorSpace;
-// pub use self::module::FiniteDimVectorSpaceApprox;
+pub use self::module::FiniteDimVectorSpaceApprox;
 pub use self::module::NormedSpaceApprox;
-// pub use self::module::InnerProductSpaceApprox;
-// pub use self::module::FiniteDimInnerProductSpaceApprox;
+pub use self::module::InnerSpaceApprox;
+pub use self::module::FiniteDimInnerSpaceApprox;
+pub use self::module::AffineSpaceApprox;
+pub use self::module::FiniteDimAffineSpaceApprox;
+pub use self::module::EuclideanSpaceApprox;
 
 mod magma;
 mod quasigroup;

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -152,7 +152,7 @@
 //!                           \       /
 //!                            |     |
 //!                            V     V
-//!                         VectorSpace<Scalar>
+//!                      VectorSpace<Scalar>
 //! ~~~
 //!
 //! The following traits are provided:
@@ -203,10 +203,16 @@ pub use self::ring::RingCommutative;
 pub use self::ring::FieldApprox;
 pub use self::ring::Field;
 
+pub use self::real::RealApprox;
+
 pub use self::module::ModuleApprox;
 pub use self::module::Module;
 pub use self::module::VectorSpaceApprox;
 pub use self::module::VectorSpace;
+// pub use self::module::FiniteDimVectorSpaceApprox;
+pub use self::module::NormedSpaceApprox;
+// pub use self::module::InnerProductSpaceApprox;
+// pub use self::module::FiniteDimInnerProductSpaceApprox;
 
 mod magma;
 mod quasigroup;
@@ -217,3 +223,4 @@ mod group;
 mod abelian;
 mod ring;
 mod module;
+mod real;

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -20,7 +20,7 @@
 //! |(• ◡•)|ノ〵(❍ᴥ❍⋃)     - "ALGEBRAIC!!!"
 //! ~~~
 //!
-//! For most applications requiring an abstraction over the reals, `FieldApprox`
+//! For most applications requiring an abstraction over the reals, `RealApprox`
 //! should be sufficient.
 //!
 //! # Fundamental algebraic structures
@@ -216,9 +216,7 @@ pub use self::module::VectorSpace;
 pub use self::module::FiniteDimVectorSpaceApprox;
 pub use self::module::NormedSpaceApprox;
 pub use self::module::InnerSpaceApprox;
-pub use self::module::FiniteDimInnerSpaceApprox;
 pub use self::module::AffineSpaceApprox;
-pub use self::module::FiniteDimAffineSpaceApprox;
 pub use self::module::EuclideanSpaceApprox;
 
 mod magma;

--- a/src/structure/module.rs
+++ b/src/structure/module.rs
@@ -21,6 +21,8 @@ use structure::RingCommutative;
 use structure::FieldApprox;
 use structure::Field;
 use structure::RealApprox;
+use structure::EuclideanGroupApprox;
+
 use ident;
 
 
@@ -92,7 +94,7 @@ pub trait NormedSpaceApprox<S: FieldApprox>
 ///
 /// It must be a normed space as well and the norm must agree with the inner product.
 /// The inner product must be symmetric, linear in its first agurment, and positive definite.
-pub trait InnerProductSpaceApprox<S: RealApprox>
+pub trait InnerSpaceApprox<S: RealApprox>
     : NormedSpaceApprox<S> {
     /// Computes the inner product of `self` with `other`.
     fn inner_product(&self, other: &Self) -> S;
@@ -134,4 +136,45 @@ pub trait FiniteDimVectorSpaceApprox<S: FieldApprox>
 
     /// Retrieves the i-th component of `Self` wrt. the canonical basis without bound checking.
     unsafe fn component_unchecked(&self, i: usize)  -> S;
+}
+
+/// A finite-dimensional inner space.
+pub trait FiniteDimInnerSpaceApprox<S: RealApprox>
+    : FiniteDimVectorSpaceApprox<S> +
+      InnerSpaceApprox<S> {
+}
+
+
+/// A set of elements called "points" associated with a vector space and a transitive and free
+/// additive group action called a "translation".
+///
+/// The group action is commonly called 
+pub trait AffineSpaceApprox<S: FieldApprox> {
+    /// The associated vector space.
+    type Vector: VectorSpaceApprox<S>;
+
+    /// Applies the additive group action of this affine space's associated vector space on `self`.
+    fn translate_by(vector: &Self::Vector) -> Self;
+
+    /// Returns the unique element `v` of the associated vector space such that `self = other + v`.
+    fn subtract(&self, other: &Self) -> Self::Vector;
+}
+
+// XXX: because of the associated type, we cannot make this inherit from `AffineSpaceApprox<S>`.
+/// A finite-dimensional affine space.
+pub trait FiniteDimAffineSpaceApprox<S: FieldApprox> {
+    /// The associated finite-dimensionale vector space.
+    type Vector: FiniteDimVectorSpaceApprox<S>;
+
+    /// Applies the additive group action of this affine space's associated vector space on `self`.
+    fn translate_by(vector: &Self::Vector) -> Self;
+
+    /// Returns the unique element `v` of the associated vector space such that `self = other + v`.
+    fn subtract(&self, other: &Self) -> Self::Vector;
+}
+
+/// A space that equips an affine space with isometries.
+pub trait EuclideanSpaceApprox<S: RealApprox>: Sized + FiniteDimAffineSpaceApprox<S> {
+    /// The type of isometries.
+    type Isometry: EuclideanGroupApprox<S, Self>;
 }

--- a/src/structure/monoid.rs
+++ b/src/structure/monoid.rs
@@ -36,8 +36,8 @@ pub trait MonoidApprox<O: Op>
     }
 }
 
-impl_marker!(MonoidApprox<Additive>; u8, u16, u32, u64, i8, i16, i32, i64);
-impl_marker!(MonoidApprox<Multiplicative>; u8, u16, u32, u64, i8, i16, i32, i64);
+impl_marker!(MonoidApprox<Additive>; u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
+impl_marker!(MonoidApprox<Multiplicative>; u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
 
 /// A semigroup equipped with an identity element.
 ///

--- a/src/structure/quasigroup.rs
+++ b/src/structure/quasigroup.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ops::{Op, Inverse, Additive};
+use ops::{Op, Inverse, Additive, Multiplicative};
 
 use structure::MagmaApprox;
 use structure::Magma;
@@ -40,7 +40,8 @@ pub trait QuasigroupApprox<O: Op>
     }
 }
 
-impl_marker!(QuasigroupApprox<Additive>; i8, i16, i32, i64);
+impl_marker!(QuasigroupApprox<Additive>; i8, i16, i32, i64, f32, f64);
+impl_marker!(QuasigroupApprox<Multiplicative>; f32, f64);
 
 /// A magma with the divisibility property.
 ///

--- a/src/structure/real.rs
+++ b/src/structure/real.rs
@@ -60,166 +60,207 @@ impl<S> RealApprox for S
 where S: Float + FieldApprox + FromPrimitive + Neg +
          AddAssign + MulAssign + SubAssign + DivAssign +
          ApproxEq<Eps = S> + Ord {
+    #[inline]
     fn floor(self) -> Self {
         self.floor()
     }
 
+    #[inline]
     fn ceil(self) -> Self {
         self.ceil()
     }
 
+    #[inline]
     fn round(self) -> Self {
         self.round()
     }
 
+    #[inline]
     fn trunc(self) -> Self {
         self.trunc()
     }
 
+    #[inline]
     fn fract(self) -> Self {
         self.fract()
     }
 
+    #[inline]
     fn abs(self) -> Self {
         self.abs()
     }
 
+    #[inline]
     fn signum(self) -> Self {
         self.signum()
     }
 
+    #[inline]
     fn is_sign_positive(self) -> bool {
         self.is_sign_positive()
     }
 
+    #[inline]
     fn is_sign_negative(self) -> bool {
         self.is_sign_negative()
     }
 
+    #[inline]
     fn mul_add(self, a: Self, b: Self) -> Self {
         self.mul_add(a, b)
     }
 
+    #[inline]
     fn recip(self) -> Self {
         self.recip()
     }
 
+    #[inline]
     fn powi(self, n: i32) -> Self {
         self.powi(n)
     }
 
+    #[inline]
     fn powf(self, n: Self) -> Self {
         self.powf(n)
     }
 
+    #[inline]
     fn sqrt(self) -> Self {
         self.sqrt()
     }
 
+    #[inline]
     fn exp(self) -> Self {
         self.exp()
     }
 
+    #[inline]
     fn exp2(self) -> Self {
         self.exp2()
     }
 
+    #[inline]
     fn ln(self) -> Self {
         self.ln()
     }
 
+    #[inline]
     fn log(self, base: Self) -> Self {
         self.log(base)
     }
 
+    #[inline]
     fn log2(self) -> Self {
         self.log2()
     }
 
+    #[inline]
     fn log10(self) -> Self {
         self.log10()
     }
 
+    #[inline]
     fn max(self, other: Self) -> Self {
         self.max(other)
     }
 
+    #[inline]
     fn min(self, other: Self) -> Self {
         self.min(other)
     }
 
+    #[inline]
     fn abs_sub(self, other: Self) -> Self {
         self.abs_sub(other)
     }
 
+    #[inline]
     fn cbrt(self) -> Self {
         self.cbrt()
     }
 
+    #[inline]
     fn hypot(self, other: Self) -> Self {
         self.hypot(other)
     }
 
+    #[inline]
     fn sin(self) -> Self {
         self.sin()
     }
 
+    #[inline]
     fn cos(self) -> Self {
         self.cos()
     }
 
+    #[inline]
     fn tan(self) -> Self {
         self.tan()
     }
 
+    #[inline]
     fn asin(self) -> Self {
         self.asin()
     }
 
+    #[inline]
     fn acos(self) -> Self {
         self.acos()
     }
 
+    #[inline]
     fn atan(self) -> Self {
         self.atan()
     }
 
+    #[inline]
     fn atan2(self, other: Self) -> Self {
         self.atan2(other)
     }
 
+    #[inline]
     fn sin_cos(self) -> (Self, Self) {
         self.sin_cos()
     }
 
+    #[inline]
     fn exp_m1(self) -> Self {
         self.exp_m1()
     }
 
+    #[inline]
     fn ln_1p(self) -> Self {
         self.ln_1p()
     }
 
+    #[inline]
     fn sinh(self) -> Self {
         self.sinh()
     }
 
+    #[inline]
     fn cosh(self) -> Self {
         self.cosh()
     }
 
+    #[inline]
     fn tanh(self) -> Self {
         self.tanh()
     }
 
+    #[inline]
     fn asinh(self) -> Self {
         self.asinh()
     }
 
+    #[inline]
     fn acosh(self) -> Self {
         self.acosh()
     }
 
+    #[inline]
     fn atanh(self) -> Self {
         self.atanh()
     }

--- a/src/structure/real.rs
+++ b/src/structure/real.rs
@@ -1,0 +1,223 @@
+use num::{Float, Num, FromPrimitive};
+use std::ops::{Neg, AddAssign, MulAssign, SubAssign, DivAssign};
+use structure::FieldApprox;
+
+#[allow(missing_docs)]
+
+/// Trait shared by all approximate reals.
+///
+/// Approximate reals are approximate fields aquipped with funtinos that are commonly used on
+/// reals. The results of those functions only have to be approximately equal to the actual
+/// theoretical values.
+pub trait RealApprox: Copy + Num + FieldApprox + FromPrimitive +
+                      Neg + AddAssign + MulAssign + SubAssign + DivAssign {
+    fn floor(self) -> Self;
+    fn ceil(self) -> Self;
+    fn round(self) -> Self;
+    fn trunc(self) -> Self;
+    fn fract(self) -> Self;
+    fn abs(self) -> Self;
+    fn signum(self) -> Self;
+    fn is_sign_positive(self) -> bool;
+    fn is_sign_negative(self) -> bool;
+    fn mul_add(self, a: Self, b: Self) -> Self;
+    fn recip(self) -> Self;
+    fn powi(self, n: i32) -> Self;
+    fn powf(self, n: Self) -> Self;
+    fn sqrt(self) -> Self;
+    fn exp(self) -> Self;
+    fn exp2(self) -> Self;
+    fn ln(self) -> Self;
+    fn log(self, base: Self) -> Self;
+    fn log2(self) -> Self;
+    fn log10(self) -> Self;
+    fn max(self, other: Self) -> Self;
+    fn min(self, other: Self) -> Self;
+    fn abs_sub(self, other: Self) -> Self;
+    fn cbrt(self) -> Self;
+    fn hypot(self, other: Self) -> Self;
+    fn sin(self) -> Self;
+    fn cos(self) -> Self;
+    fn tan(self) -> Self;
+    fn asin(self) -> Self;
+    fn acos(self) -> Self;
+    fn atan(self) -> Self;
+    fn atan2(self, other: Self) -> Self;
+    fn sin_cos(self) -> (Self, Self);
+    fn exp_m1(self) -> Self;
+    fn ln_1p(self) -> Self;
+    fn sinh(self) -> Self;
+    fn cosh(self) -> Self;
+    fn tanh(self) -> Self;
+    fn asinh(self) -> Self;
+    fn acosh(self) -> Self;
+    fn atanh(self) -> Self;
+}
+
+impl<S> RealApprox for S
+where S: Float + FieldApprox + FromPrimitive + Neg +
+         AddAssign + MulAssign + SubAssign + DivAssign {
+    fn floor(self) -> Self {
+        self.floor()
+    }
+
+    fn ceil(self) -> Self {
+        self.ceil()
+    }
+
+    fn round(self) -> Self {
+        self.round()
+    }
+
+    fn trunc(self) -> Self {
+        self.trunc()
+    }
+
+    fn fract(self) -> Self {
+        self.fract()
+    }
+
+    fn abs(self) -> Self {
+        self.abs()
+    }
+
+    fn signum(self) -> Self {
+        self.signum()
+    }
+
+    fn is_sign_positive(self) -> bool {
+        self.is_sign_positive()
+    }
+
+    fn is_sign_negative(self) -> bool {
+        self.is_sign_negative()
+    }
+
+    fn mul_add(self, a: Self, b: Self) -> Self {
+        self.mul_add(a, b)
+    }
+
+    fn recip(self) -> Self {
+        self.recip()
+    }
+
+    fn powi(self, n: i32) -> Self {
+        self.powi(n)
+    }
+
+    fn powf(self, n: Self) -> Self {
+        self.powf(n)
+    }
+
+    fn sqrt(self) -> Self {
+        self.sqrt()
+    }
+
+    fn exp(self) -> Self {
+        self.exp()
+    }
+
+    fn exp2(self) -> Self {
+        self.exp2()
+    }
+
+    fn ln(self) -> Self {
+        self.ln()
+    }
+
+    fn log(self, base: Self) -> Self {
+        self.log(base)
+    }
+
+    fn log2(self) -> Self {
+        self.log2()
+    }
+
+    fn log10(self) -> Self {
+        self.log10()
+    }
+
+    fn max(self, other: Self) -> Self {
+        self.max(other)
+    }
+
+    fn min(self, other: Self) -> Self {
+        self.min(other)
+    }
+
+    fn abs_sub(self, other: Self) -> Self {
+        self.abs_sub(other)
+    }
+
+    fn cbrt(self) -> Self {
+        self.cbrt()
+    }
+
+    fn hypot(self, other: Self) -> Self {
+        self.hypot(other)
+    }
+
+    fn sin(self) -> Self {
+        self.sin()
+    }
+
+    fn cos(self) -> Self {
+        self.cos()
+    }
+
+    fn tan(self) -> Self {
+        self.tan()
+    }
+
+    fn asin(self) -> Self {
+        self.asin()
+    }
+
+    fn acos(self) -> Self {
+        self.acos()
+    }
+
+    fn atan(self) -> Self {
+        self.atan()
+    }
+
+    fn atan2(self, other: Self) -> Self {
+        self.atan2(other)
+    }
+
+    fn sin_cos(self) -> (Self, Self) {
+        self.sin_cos()
+    }
+
+    fn exp_m1(self) -> Self {
+        self.exp_m1()
+    }
+
+    fn ln_1p(self) -> Self {
+        self.ln_1p()
+    }
+
+    fn sinh(self) -> Self {
+        self.sinh()
+    }
+
+    fn cosh(self) -> Self {
+        self.cosh()
+    }
+
+    fn tanh(self) -> Self {
+        self.tanh()
+    }
+
+    fn asinh(self) -> Self {
+        self.asinh()
+    }
+
+    fn acosh(self) -> Self {
+        self.acosh()
+    }
+
+    fn atanh(self) -> Self {
+        self.atanh()
+    }
+}

--- a/src/structure/real.rs
+++ b/src/structure/real.rs
@@ -1,5 +1,6 @@
 use num::{Float, Num, FromPrimitive};
 use std::ops::{Neg, AddAssign, MulAssign, SubAssign, DivAssign};
+use cmp::ApproxEq;
 use structure::FieldApprox;
 
 #[allow(missing_docs)]
@@ -10,7 +11,8 @@ use structure::FieldApprox;
 /// reals. The results of those functions only have to be approximately equal to the actual
 /// theoretical values.
 pub trait RealApprox: Copy + Num + FieldApprox + FromPrimitive +
-                      Neg + AddAssign + MulAssign + SubAssign + DivAssign {
+                      Neg<Output = Self> + AddAssign + MulAssign + SubAssign + DivAssign +
+                      ApproxEq<Eps = Self> + Ord {
     fn floor(self) -> Self;
     fn ceil(self) -> Self;
     fn round(self) -> Self;
@@ -56,7 +58,8 @@ pub trait RealApprox: Copy + Num + FieldApprox + FromPrimitive +
 
 impl<S> RealApprox for S
 where S: Float + FieldApprox + FromPrimitive + Neg +
-         AddAssign + MulAssign + SubAssign + DivAssign {
+         AddAssign + MulAssign + SubAssign + DivAssign +
+         ApproxEq<Eps = S> + Ord {
     fn floor(self) -> Self {
         self.floor()
     }

--- a/src/structure/real.rs
+++ b/src/structure/real.rs
@@ -7,7 +7,7 @@ use structure::FieldApprox;
 
 /// Trait shared by all approximate reals.
 ///
-/// Approximate reals are approximate fields aquipped with funtinos that are commonly used on
+/// Approximate reals are approximate fields aquipped with functions that are commonly used on
 /// reals. The results of those functions only have to be approximately equal to the actual
 /// theoretical values.
 pub trait RealApprox: Copy + Num + FieldApprox + FromPrimitive +

--- a/src/structure/ring.rs
+++ b/src/structure/ring.rs
@@ -44,7 +44,7 @@ pub trait RingApprox
     }
 }
 
-impl_marker!(RingApprox; i8, i16, i32, i64);
+impl_marker!(RingApprox; i8, i16, i32, i64, f32, f64);
 
 
 /// A ring is the combination of an abelian group and a multiplicative monoid structure.
@@ -87,7 +87,7 @@ pub trait RingCommutativeApprox
     }
 }
 
-impl_marker!(RingCommutativeApprox; i8, i16, i32, i64);
+impl_marker!(RingCommutativeApprox; i8, i16, i32, i64, f32, f64);
 
 
 /// An ring with a commutative multiplication.
@@ -115,6 +115,7 @@ pub trait FieldApprox
     + GroupAbelianApprox<Multiplicative>
 {}
 
+impl_marker!(FieldApprox; f32, f64);
 
 /// A field is a commutative ring, and an abelian group under the multiplication operator.
 pub trait Field

--- a/src/structure/ring.rs
+++ b/src/structure/ring.rs
@@ -15,13 +15,12 @@
 use ops::{Additive, Multiplicative};
 use cmp::ApproxEq;
 
-use wrapper::Wrapper as W;
-
 use structure::MonoidApprox;
 use structure::Monoid;
 use structure::GroupAbelianApprox;
 use structure::GroupAbelian;
 
+use wrapper::Wrapper as W;
 
 /// An approximate ring is given the approximate version of the ring's properties.
 ///

--- a/src/structure/semigroup.rs
+++ b/src/structure/semigroup.rs
@@ -33,8 +33,8 @@ pub trait SemigroupApprox<O: Op>
     }
 }
 
-impl_marker!(SemigroupApprox<Additive>; u8, u16, u32, u64, i8, i16, i32, i64);
-impl_marker!(SemigroupApprox<Multiplicative>; u8, u16, u32, u64, i8, i16, i32, i64);
+impl_marker!(SemigroupApprox<Additive>; u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
+impl_marker!(SemigroupApprox<Multiplicative>; u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
 
 /// An associative magma.
 ///


### PR DESCRIPTION
The work is done only for `Approx` versions of the traits.

This adds all the structures that are needed to define an euclidean space. This include the isometry group `E(n)` and all its common subgroups `O(n)`, `SO(n)`, and `SE(n)`. Euclidean spaces work only with reals and need some operations that are not part of a field (e.g. cosinus, square root, etc.) So I added a `RealApprox` trait for reals. This is the same as the `num::Float` trait, except that it does not include float-specific methods like `is_infinite()`, `is_nan()`, etc.

Also, `f32` and `f64` now implement the `FieldApprox` trait.
